### PR TITLE
Fix Inspire HTTP client

### DIFF
--- a/src/Inspire.php
+++ b/src/Inspire.php
@@ -2,12 +2,14 @@
 
 namespace Yusef22\Inspire;
 
-use Illuminate\Support\Facades\Http;
+use GuzzleHttp\Client;
 
 class Inspire {
     public function justDoIt() {
-        $response = Http::get('https://inspiration.goprogram.ai/');
+        $client = new Client();
+        $response = $client->get('https://inspiration.goprogram.ai/');
+        $data = json_decode($response->getBody()->getContents(), true);
 
-        return $response['quote'] . ' -' . $response['author'];
+        return $data['quote'] . ' -' . $data['author'];
     }
 }


### PR DESCRIPTION
## Summary
- remove use of Laravel `Http` facade
- leverage `GuzzleHttp\Client` for remote calls

## Testing
- `composer validate`
- `php -l src/Inspire.php`

------
https://chatgpt.com/codex/tasks/task_e_6885d780ee648321aa1d02115574255b