### PR TITLE
Switch package to random Hafez poems

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # inspire
+
+This package provides a simple route that displays a random verse from the
+Persian poet **Hafez**. After installing the package and visiting the `/inspire`
+route, you will see a randomly selected poem every time the page is refreshed.

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,5 @@
         }
     ],
     "require": {
-        "guzzlehttp/guzzle": "^7.0.1"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,18 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "0ea8c7b3ec8865c7059b36f5709d228f",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
+}

--- a/src/Inspire.php
+++ b/src/Inspire.php
@@ -2,12 +2,27 @@
 
 namespace Yusef22\Inspire;
 
-use Illuminate\Support\Facades\Http;
-
 class Inspire {
-    public function justDoIt() {
-        $response = Http::get('https://inspiration.goprogram.ai/');
+    /**
+     * Collection of Hafez poems used for random selection.
+     *
+     * @var array<int, string>
+     */
+    protected array $poems = [
+        'الا یا ایها الساقی ادر کاسا و ناولها که عشق آسان نمود اول ولی افتاد مشکل‌ها',
+        'دوش دیدم که ملائک در میخانه زدند گل آدم بسرشتند و به پیمانه زدند',
+        'منم که شهره شهرم به عشق ورزیدن منم که دیده نیالوده‌ام به بد دیدن',
+        'حافظا می خور و رندی کن و خوش باش ولی دام تزویر مکن چون دگران قرق کنی',
+        'چو بشنوی سخن اهل دل مگو که خطاست سخن شناس نه‌ای جان من خطا اینجا است',
+    ];
 
-        return $response['quote'] . ' -' . $response['author'];
+    /**
+     * Return a random verse from Hafez.
+     */
+    public function justDoIt(): string
+    {
+        $poem = $this->poems[array_rand($this->poems)];
+
+        return $poem . ' - حافظ';
     }
 }


### PR DESCRIPTION
## Summary
- remove Guzzle dependency
- store a list of Hafez poems and randomly show one on `/inspire`
- update README

## Testing
- `composer validate --no-check-publish`
- `composer install`
- `php -l src/Inspire.php`
- `php -l src/Controllers/InspirationController.php`
- `php -l src/Providers/InspirationProvider.php`
- `php -l src/routes/web.php`
- `php -l src/views/index.blade.php`


------
https://chatgpt.com/codex/tasks/task_e_6885d7e395188321bfc444d71dba6438